### PR TITLE
V3 ldm opt improvements

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-
+    printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    printf("--NEW BLOCK--\n");
+    //printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;
@@ -2338,7 +2338,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = {NULL, NULL, 0, 0, 0};
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -87,6 +87,19 @@ typedef struct {
 } ZSTD_match_t;
 
 typedef struct {
+    U32 offset;
+    U32 litLength;
+    U32 matchLength;
+} rawSeq;
+
+typedef struct {
+  rawSeq* seq;     /* The start of the sequences */
+  size_t pos;      /* The position where reading stopped. <= size. */
+  size_t size;     /* The number of sequences. <= capacity. */
+  size_t capacity; /* The capacity starting from `seq` pointer */
+} rawSeqStore_t;
+
+typedef struct {
     int price;
     U32 off;
     U32 mlen;
@@ -152,6 +165,7 @@ struct ZSTD_matchState_t {
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;
+    rawSeqStore_t ldmSeqStore;
 };
 
 typedef struct {
@@ -182,19 +196,6 @@ typedef struct {
     U32 hashRateLog;       /* Log number of entries to skip */
     U32 windowLog;          /* Window log for the LDM */
 } ldmParams_t;
-
-typedef struct {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
-} rawSeq;
-
-typedef struct {
-  rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The position where reading stopped. <= size. */
-  size_t size;     /* The number of sequences. <= capacity. */
-  size_t capacity; /* The capacity starting from `seq` pointer */
-} rawSeqStore_t;
 
 typedef struct {
     int collectSequences;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,6 +94,7 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
+  BYTE const* base;
   size_t pos;      /* The position where reading stopped. <= size. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -576,6 +576,13 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     /* Input positions */
     BYTE const* ip = istart;
 
+    if (cParams->strategy >= ZSTD_btopt) {
+        size_t lastLLSize;
+        ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        return lastLLSize;
+    }
+
     DEBUGLOG(5, "ZSTD_ldm_blockCompress: srcSize=%zu", srcSize);
     assert(rawSeqStore->pos <= rawSeqStore->size);
     assert(rawSeqStore->size <= rawSeqStore->capacity);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -562,6 +562,13 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
+static void printSeqStore(rawSeqStore_t* rawSeqStore) {
+    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    for (int i = 0; i < rawSeqStore->size; ++i) {
+        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+    }
+}
+
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
     void const* src, size_t srcSize)
@@ -578,6 +585,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
 
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
+        printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -580,6 +580,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        rawSeqStore->pos = ms->ldmSeqStore.pos;
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -563,9 +563,9 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
 }
 
 static void printSeqStore(rawSeqStore_t* rawSeqStore) {
-    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    printf("rawSeqStore: pos: %zu\n", rawSeqStore->pos);
     for (int i = 0; i < rawSeqStore->size; ++i) {
-        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+        printf("pos %d (of:%u ml:%u ll: %u)\n", i, rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
     }
 }
 
@@ -582,20 +582,19 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
-
+    //printSeqStore(rawSeqStore);
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
-        printSeqStore(rawSeqStore);
+        //printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
-        const BYTE* const prevBase = (BYTE const*)ms->window.base;
+        ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        rawSeqStore->pos = ms->ldmSeqStore.pos;
-        ms->ldmSeqStore = *rawSeqStore;
-        if (prevBase != ms->window.base) {
+        *rawSeqStore = ms->ldmSeqStore;
+        /*if (prevBase != ms->window.base) {
             int baseDiff = (int)(prevBase - ms->window.base);
             printf("Bases were different, adjusting, diff = %d\n", baseDiff);
             rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
-        }
+        }*/
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -579,8 +579,15 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
         rawSeqStore->pos = ms->ldmSeqStore.pos;
+        ms->ldmSeqStore = *rawSeqStore;
+        if (prevBase != ms->window.base) {
+            int baseDiff = (int)(prevBase - ms->window.base);
+            printf("Bases were different, adjusting, diff = %d\n", baseDiff);
+            rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
+        }
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -940,7 +940,10 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     U32 ldmEndPosInBlock = 0;
     U32 ldmOffset = 0;
     
-
+    if (ms->ldmSeqStore.size != 0) {
+        ldm_getNextMatch(&ms->ldmSeqStore, &ldmStartPosInBlock,
+                &ldmEndPosInBlock, &ldmOffset, (U32)(ip-istart), (U32)(iend-ip));
+    }
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_opt_generic: current=%u, prefix=%u, nextToUpdate=%u",
                 (U32)(ip - base), ms->window.dictLimit, ms->nextToUpdate);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -788,7 +788,7 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 }
 
 /* Wrapper function to call ldm functions as needed */
-static void ldm_handleLdm() {
+static void ldm_handleLdm(int* nbMatches) {
     int noMoreLdms = getNextMatch();
 }
 
@@ -861,6 +861,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
         {   U32 const litlen = (U32)(ip - anchor);
             U32 const ll0 = !litlen;
             U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, ip, iend, dictMode, rep, ll0, minMatch);
+            ldm_handleLdm(&nbMatches);
             if (!nbMatches) { ip++; continue; }
 
             /* initialize opt[0] */
@@ -975,6 +976,8 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                 U32 const basePrice = previousPrice + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, inr, iend, dictMode, opt[cur].rep, ll0, minMatch);
                 U32 matchNb;
+                
+                ldm_handleLdm(&nbMatches);
                 if (!nbMatches) {
                     DEBUGLOG(7, "rPos:%u : no match found", cur);
                     continue;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -838,8 +838,20 @@ static int ldm_getNextMatch(rawSeqStore_t* ldmSeqStore,
 }
 
 /* Adds an LDM if it's long enough */
-static void ldm_maybeAddLdm() {
+static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32 nbMatches,
+                            U32 matchStartPosInBlock, U32 matchEndPosInBlock,
+                            U32 matchOffset, U32 currPosInBlock) {
+    /* Check that current block position is not outside of the match */
+    if (currPosInBlock < matchStartPosInBlock || currPosInBlock >= matchEndPosInBlock)
+        return;
+    U32 posDiff = currPosInBlock - matchStartPosInBlock;
+    assert(posDiff < matchEndPosInBlock - matchStartPosInBlock);
+    U32 matchLengthAdjusted = matchEndPosInBlock - matchStartPosInBlock - posDiff;
+    U32 matchOffsetAdjusted = matchOffset + posDiff;
 
+    if (matchLengthAdjusted >= matches[nbMatches-1]) {
+        
+    }
 }
 
 /* Updates the pos field in rawSeqStore */
@@ -849,12 +861,12 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 
 /* Wrapper function to call ldm functions as needed */
 static void ldm_handleLdm(ZSTD_match_t* matches, int* nbMatches,
-                          U32* matchStartPosInBlock, U32* matchEndPosInBlock,
+                          U32* matchStartPosInBlock, U32* matchEndPosInBlock, U32* matchOffset,
                           U32 currPosInBlock, U32 remainingBytes) {
     if (currPosInBlock >= matchEndPosInBlock) {
         int noMoreLdms = ldm_getNextMatch(matchStartPosInBlock, matchEndPosInBlock, remainingBytes);
     }
-    ldm_maybeAddLdm(matches, currPosInBlock, matchStartPosInBlock, matchEndPosInBlock);
+    ldm_maybeAddLdm(matches, *nbMatches, *matchStartPosInBlock, *matchEndPosInBlock, *matchOffset, currPosInBlock);
 }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -764,6 +764,34 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
     }
 }
 
+/*-*******************************
+*  LDM util functions
+*********************************/
+
+static int ldm_splitSequence() {
+
+}
+
+/* Returns 1 if the rest of the block is just LDM literals */
+static int ldm_getNextMatch() {
+    int ret = ldm_splitSequence();
+}
+
+/* Adds an LDM if it's long enough */
+static void ldm_maybeAddLdm() {
+
+}
+
+/* Updates the pos field in rawSeqStore */
+static void ldm_maybeUpdateSeqStoreReadPos() {
+
+}
+
+/* Wrapper function to call ldm functions as needed */
+static void ldm_handleLdm() {
+    int noMoreLdms = getNextMatch();
+}
+
 
 /*-*******************************
 *  Optimal parser

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -789,6 +789,15 @@ static void ldm_skipOvershotBytes(rawSeqStore_t* rawSeqStore, U32 bytesOvershot)
     }
 }*/
 
+
+static void ldm_voidSequences(rawSeqStore_t* ldmSeqStore, U32 overshotBytes) {
+    U32 posAdjustment;
+    U32 bytesAdjustment;
+    while (overshotBytes > 0 && ldmSeqStore->pos < ldmSeqStore->size) {
+
+    }
+}
+
 static void ldm_skipSequences(rawSeqStore_t* rawSeqStore, size_t srcSize, U32 const minMatch) {
     while (srcSize > 0 && rawSeqStore->pos < rawSeqStore->size) {
         printf("ldm_skipSequences(): %u remaining\n", srcSize);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, 0, 0, 0};
+    rawSeqStore_t seq = {NULL, NULL, 0, 0, 0};
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;


### PR DESCRIPTION
Draft PR
Preliminary results regarding compressed size:

* 5259889920 (5GB) bytes: 5 Linux kernels concatenated: versions 4.19.148, 5.4.68, 5.8.12, 5.9-rc7, 5.8.12: 
    * Old: Level 22 - long mode - window log = 27
        * 622643668 → 11.8376%
    * Old: Level 22 - no long mode - window log = 27
        * 624737369 → 11.8774%
    * New: Level 22 - long mode - window log = 27
        * 622639116 → 11.8375%
* 211950592 (200MB) bytes: silesia.tar
    * Old: Level 22 - long mode - window log = 27
        * 52777588 → 24.900%
    * Old: Level 22 - no long mode - window log = 27
        * 52701591 → 24.865%
    * New: Level 22 - long mode - window log = 27
        * 52699843 → 24.864% 

New algorithm approach:

* Essentially, we will use the LDM rawSeqStore given to us in a similar way to the current LDM insertion algorithm works. What this means is that essentially for each new block, the LDM sequence at position pos within the LDM seqStore is guaranteed to start at the same relative position as the block. That is, for each n bytes processed in the block, n bytes are processed and consumed in the LDM seqstore, and the member pos will point to relevant sequence.
* As such, all of our calculations are purely relative within each block, and the approach is robust against issues such as window updates, etc.

