### PR TITLE
Version 3 ldm opt

### DIFF
--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2338,7 +2338,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, NULL, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0, 0};
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-
+    
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    
+
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-
+    printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    printf("--NEW BLOCK--\n");
+    //printf("--NEW BLOCK--\n");
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;
@@ -2338,7 +2338,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
                                        src, srcSize);
             assert(zc->externSeqStore.pos <= zc->externSeqStore.size);
         } else if (zc->appliedParams.ldmParams.enableLdm) {
-            rawSeqStore_t ldmSeqStore = {NULL, 0, 0, 0};
+            rawSeqStore_t ldmSeqStore = {NULL, NULL, 0, 0, 0};
 
             ldmSeqStore.seq = zc->ldmSequences;
             ldmSeqStore.capacity = zc->maxNbLdmSequences;

--- a/lib/compress/zstd_compress.c
+++ b/lib/compress/zstd_compress.c
@@ -2320,7 +2320,7 @@ static size_t ZSTD_buildSeqStore(ZSTD_CCtx* zc, const void* src, size_t srcSize)
         if (curr > ms->nextToUpdate + 384)
             ms->nextToUpdate = curr - MIN(192, (U32)(curr - ms->nextToUpdate - 384));
     }
-    //printf("--NEW BLOCK--\n");
+
     /* select and store sequences */
     {   ZSTD_dictMode_e const dictMode = ZSTD_matchState_dictMode(ms);
         size_t lastLLSize;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -82,23 +82,23 @@ typedef struct {
 } ZSTD_entropyCTables_t;
 
 typedef struct {
-    U32 off;
-    U32 len;
+    U32 off;            /* Offset code for the match */
+    U32 len;            /* Raw length of match */
 } ZSTD_match_t;
 
 typedef struct {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
+    U32 offset;         /* Offset of sequence */
+    U32 litLength;      /* Length of literals prior to match */
+    U32 matchLength;    /* Raw length of match */
 } rawSeq;
 
 typedef struct {
-  rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The index in this seqStore where reading stopped. <= size. */
-  size_t posInSequence; /* The position within the rawSeq at index 'pos' where reading
-                           stopped. */
-  size_t size;     /* The number of sequences. <= capacity. */
-  size_t capacity; /* The capacity starting from `seq` pointer */
+  rawSeq* seq;          /* The start of the sequences */
+  size_t pos;           /* The index in seq where reading stopped. pos <= size. */
+  size_t posInSequence; /* The position within the sequence at seq[pos] where reading
+                           stopped. posInSequence <= seq[pos].litLength + seq[pos].matchLength */
+  size_t size;          /* The number of sequences. <= capacity. */
+  size_t capacity;      /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;
 
 typedef struct {

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,8 +94,9 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The position where reading stopped. <= size. */
-  size_t posInSequence; /* The position to start at within the sequence when starting a new block */
+  size_t pos;      /* The index in this seqStore where reading stopped. <= size. */
+  size_t posInSequence; /* The position within the rawSeq at index 'pos' where reading
+                           stopped. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,8 +94,8 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  BYTE const* base; /* The match state window base when LDMs were generated */
   size_t pos;      /* The position where reading stopped. <= size. */
+  size_t posInSequence; /* The position to start at within the sequence when starting a new block */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */
 } rawSeqStore_t;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -82,7 +82,7 @@ typedef struct {
 } ZSTD_entropyCTables_t;
 
 typedef struct {
-    U32 off;            /* Offset code for the match */
+    U32 off;            /* Offset code (offset + ZSTD_REP_MOVE) for the match */
     U32 len;            /* Raw length of match */
 } ZSTD_match_t;
 

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -87,6 +87,19 @@ typedef struct {
 } ZSTD_match_t;
 
 typedef struct {
+    U32 offset;
+    U32 litLength;
+    U32 matchLength;
+} rawSeq;
+
+typedef struct {
+  rawSeq* seq;     /* The start of the sequences */
+  size_t pos;      /* The position where reading stopped. <= size. */
+  size_t size;     /* The number of sequences. <= capacity. */
+  size_t capacity; /* The capacity starting from `seq` pointer */
+} rawSeqStore_t;
+
+typedef struct {
     int price;
     U32 off;
     U32 mlen;
@@ -152,6 +165,7 @@ struct ZSTD_matchState_t {
     optState_t opt;         /* optimal parser state */
     const ZSTD_matchState_t* dictMatchState;
     ZSTD_compressionParameters cParams;
+    rawSeqStore_t ldmSeqStore;
 };
 
 typedef struct {
@@ -182,19 +196,6 @@ typedef struct {
     U32 hashRateLog;       /* Log number of entries to skip */
     U32 windowLog;          /* Window log for the LDM */
 } ldmParams_t;
-
-typedef struct {
-    U32 offset;
-    U32 litLength;
-    U32 matchLength;
-} rawSeq;
-
-typedef struct {
-  rawSeq* seq;     /* The start of the sequences */
-  size_t pos;      /* The position where reading stopped. <= size. */
-  size_t size;     /* The number of sequences. <= capacity. */
-  size_t capacity; /* The capacity starting from `seq` pointer */
-} rawSeqStore_t;
 
 typedef struct {
     int collectSequences;

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,7 +94,7 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
-  BYTE const* base;
+  BYTE const* base; /* The match state window base when LDMs were generated */
   size_t pos;      /* The position where reading stopped. <= size. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */

--- a/lib/compress/zstd_compress_internal.h
+++ b/lib/compress/zstd_compress_internal.h
@@ -94,6 +94,7 @@ typedef struct {
 
 typedef struct {
   rawSeq* seq;     /* The start of the sequences */
+  BYTE const* base;
   size_t pos;      /* The position where reading stopped. <= size. */
   size_t size;     /* The number of sequences. <= capacity. */
   size_t capacity; /* The capacity starting from `seq` pointer */

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -578,7 +578,6 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;
-        ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
         /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
         *rawSeqStore = ms->ldmSeqStore;

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -579,8 +579,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
-        *rawSeqStore = ms->ldmSeqStore;
+        *rawSeqStore = ms->ldmSeqStore;  /* Persist changes to ldmSeqStore during blockCompressor() */
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -562,13 +562,6 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
-static void printSeqStore(rawSeqStore_t* rawSeqStore) {
-    printf("rawSeqStore: pos: %zu\n", rawSeqStore->pos);
-    for (int i = 0; i < rawSeqStore->size; ++i) {
-        printf("pos %d (of:%u ml:%u ll: %u)\n", i, rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
-    }
-}
-
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
     void const* src, size_t srcSize)
@@ -582,19 +575,13 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
-    //printSeqStore(rawSeqStore);
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
-        //printSeqStore(rawSeqStore);
-        ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        ms->ldmSeqStore = *rawSeqStore;
         ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        /* ldm seqstore will have changed during blockCompressor() call, make sure we copy those changes */
         *rawSeqStore = ms->ldmSeqStore;
-        /*if (prevBase != ms->window.base) {
-            int baseDiff = (int)(prevBase - ms->window.base);
-            printf("Bases were different, adjusting, diff = %d\n", baseDiff);
-            rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
-        }*/
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -576,6 +576,13 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     /* Input positions */
     BYTE const* ip = istart;
 
+    if (cParams->strategy >= ZSTD_btopt) {
+        size_t lastLLSize;
+        ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        return lastLLSize;
+    }
+
     DEBUGLOG(5, "ZSTD_ldm_blockCompress: srcSize=%zu", srcSize);
     assert(rawSeqStore->pos <= rawSeqStore->size);
     assert(rawSeqStore->size <= rawSeqStore->capacity);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -562,6 +562,13 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
     return sequence;
 }
 
+static void printSeqStore(rawSeqStore_t* rawSeqStore) {
+    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    for (int i = 0; i < rawSeqStore->size; ++i) {
+        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+    }
+}
+
 size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     ZSTD_matchState_t* ms, seqStore_t* seqStore, U32 rep[ZSTD_REP_NUM],
     void const* src, size_t srcSize)
@@ -578,6 +585,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
 
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
+        printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -580,6 +580,7 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
+        rawSeqStore->pos = ms->ldmSeqStore.pos;
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -563,9 +563,9 @@ static rawSeq maybeSplitSequence(rawSeqStore_t* rawSeqStore,
 }
 
 static void printSeqStore(rawSeqStore_t* rawSeqStore) {
-    printf("rawSeqStore: pos: %zu, bytesDiscarded: %zu\n", rawSeqStore->pos);
+    printf("rawSeqStore: pos: %zu\n", rawSeqStore->pos);
     for (int i = 0; i < rawSeqStore->size; ++i) {
-        printf("(of:%u ml:%u ll: %u)\n", rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
+        printf("pos %d (of:%u ml:%u ll: %u)\n", i, rawSeqStore->seq[i].offset, rawSeqStore->seq[i].matchLength, rawSeqStore->seq[i].litLength);
     }
 }
 
@@ -582,20 +582,19 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     BYTE const* const iend = istart + srcSize;
     /* Input positions */
     BYTE const* ip = istart;
-
+    //printSeqStore(rawSeqStore);
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
-        printSeqStore(rawSeqStore);
+        //printSeqStore(rawSeqStore);
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
-        const BYTE* const prevBase = (BYTE const*)ms->window.base;
+        ms->ldmSeqStore.base = ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
-        rawSeqStore->pos = ms->ldmSeqStore.pos;
-        ms->ldmSeqStore = *rawSeqStore;
-        if (prevBase != ms->window.base) {
+        *rawSeqStore = ms->ldmSeqStore;
+        /*if (prevBase != ms->window.base) {
             int baseDiff = (int)(prevBase - ms->window.base);
             printf("Bases were different, adjusting, diff = %d\n", baseDiff);
             rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
-        }
+        }*/
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_ldm.c
+++ b/lib/compress/zstd_ldm.c
@@ -579,8 +579,15 @@ size_t ZSTD_ldm_blockCompress(rawSeqStore_t* rawSeqStore,
     if (cParams->strategy >= ZSTD_btopt) {
         size_t lastLLSize;
         ms->ldmSeqStore = *rawSeqStore; /* copy current seqStore */
+        const BYTE* const prevBase = (BYTE const*)ms->window.base;
         lastLLSize = blockCompressor(ms, seqStore, rep, src, srcSize);
         rawSeqStore->pos = ms->ldmSeqStore.pos;
+        ms->ldmSeqStore = *rawSeqStore;
+        if (prevBase != ms->window.base) {
+            int baseDiff = (int)(prevBase - ms->window.base);
+            printf("Bases were different, adjusting, diff = %d\n", baseDiff);
+            rawSeqStore->seq[rawSeqStore->pos].litLength += baseDiff;
+        }
         return lastLLSize;
     }
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -1364,6 +1364,7 @@ ZSTD_initStats_ultra(ZSTD_matchState_t* ms,
                const void* src, size_t srcSize)
 {
     U32 tmpRep[ZSTD_REP_NUM];  /* updated rep codes will sink here */
+    rawSeqStore_t tmpSeqStore = ms->ldmSeqStore;
     ZSTD_memcpy(tmpRep, rep, sizeof(tmpRep));
 
     DEBUGLOG(4, "ZSTD_initStats_ultra (srcSize=%zu)", srcSize);
@@ -1380,6 +1381,7 @@ ZSTD_initStats_ultra(ZSTD_matchState_t* ms,
     ms->window.dictLimit += (U32)srcSize;
     ms->window.lowLimit = ms->window.dictLimit;
     ms->nextToUpdate = ms->window.dictLimit;
+    ms->ldmSeqStore = tmpSeqStore;
 
     /* re-inforce weight of collected statistics */
     ZSTD_upscaleStats(&ms->opt);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -849,6 +849,8 @@ static void ldm_getNextMatchAndUpdateSeqStore(rawSeqStore_t* ldmSeqStore,
         ldmSeqStore->posInSequence = 0;
         ldmSeqStore->pos++;
     }
+    DEBUGLOG(6, "ldm_getNextMatchAndUpdateSeqStore(): got an ldm that beginning at pos: %u, end at pos: %u, with offset: %u",
+             *matchStartPosInBlock, *matchEndPosInBlock, *matchOffset);
 }
 
 /* ldm_maybeAddLdm():
@@ -870,6 +872,8 @@ static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
         candidateMatchLength < MINMATCH)
         return;
 
+    DEBUGLOG(6, "ldm_maybeAddLdm(): Adding ldm candidate match (offCode: %u matchLength %u) at block position=%u",
+             candidateOffCode, candidateMatchLength, currPosInBlock);
     if (*nbMatches == 0) {
         matches[*nbMatches].len = candidateMatchLength;
         matches[*nbMatches].off = candidateOffCode;
@@ -985,14 +989,14 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     U32 ldmStartPosInBlock = 0;
     U32 ldmEndPosInBlock = 0;
     U32 ldmOffset = 0;
-    
+
     /* Get first match from ldm seq store if long mode is enabled */
     if (ms->ldmSeqStore.size > 0 && ms->ldmSeqStore.pos < ms->ldmSeqStore.size) {
         ldm_getNextMatchAndUpdateSeqStore(&ms->ldmSeqStore, &ldmStartPosInBlock,
                                           &ldmEndPosInBlock, &ldmOffset,
                                           (U32)(ip-istart), (U32)(iend-ip));
     }
-
+    
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_opt_generic: current=%u, prefix=%u, nextToUpdate=%u",
                 (U32)(ip - base), ms->window.dictLimit, ms->nextToUpdate);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -868,6 +868,10 @@ static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32* nbMatches,
          * the ldm match down as necessary.
          */
         if (candidateMatchLength == matches[*nbMatches-1].len) {
+            if (candidateOffCode == matches[*nbMatches-1].off) {
+                /* No need to insert the match if it's the exact same */
+                return;
+            }
             U32 candidateMatchIdx = *nbMatches;
             matches[*nbMatches].len = candidateMatchLength;
             matches[*nbMatches].off = candidateOffCode;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -986,11 +986,11 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
      * since the base shifts back 131072 bytes (1 block) after the first block. The consequence is that
      * we should insert 35373 bytes into the 8th block, rather than 35373 bytes into the 7th block.
      */
-    if (ms->ldmSeqStore.size > 0) {
+    if (ms->ldmSeqStore.size > 0 && ms->ldmSeqStore.pos != ms->ldmSeqStore.size) {
         if (ms->ldmSeqStore.base != base) {
             int baseDiff = (int)(ms->ldmSeqStore.base - base);
             ms->ldmSeqStore.seq[ms->ldmSeqStore.pos].litLength += baseDiff;
-            ms->ldmSeqStore.base = ms->window.base;
+            ms->ldmSeqStore.base = base;
         }
         ldm_getNextMatch(&ms->ldmSeqStore, &ldmStartPosInBlock,
                          &ldmEndPosInBlock, &ldmOffset,

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -940,7 +940,10 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
     U32 ldmEndPosInBlock = 0;
     U32 ldmOffset = 0;
     
-
+    if (ms->ldmSeqStore.size != 0) {
+        ldm_getNextMatch(&ms->ldmSeqStore, &ldmStartPosInBlock,
+                &ldmEndPosInBlock, &ldmOffset, (U32)(ip-istart), (U32)(iend-ip));
+    }
     /* init */
     DEBUGLOG(5, "ZSTD_compressBlock_opt_generic: current=%u, prefix=%u, nextToUpdate=%u",
                 (U32)(ip - base), ms->window.dictLimit, ms->nextToUpdate);

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -824,19 +824,19 @@ static void ldm_getNextMatch(rawSeqStore_t* ldmSeqStore,
     if (ldmSeqStore->pos >= ldmSeqStore->size) {
         *matchStartPosInBlock = UINT32_MAX;
         *matchEndPosInBlock = UINT32_MAX;
-        return 1;
+        return;
     }
     rawSeq seq = ldm_splitSequenceAndUpdateSeqStore(ldmSeqStore, remainingBytes);
     if (seq.offset == 0) {
         *matchStartPosInBlock = UINT32_MAX;
         *matchEndPosInBlock = UINT32_MAX;
-        return 1;
+        return;
     }
 
     *matchStartPosInBlock = currPosInBlock + seq.litLength;
     *matchEndPosInBlock = *matchStartPosInBlock + seq.matchLength;
     *matchOffset = seq.offset;
-    return 0;
+    return;
 }
 
 /* Adds an LDM if it's long enough */

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -788,7 +788,7 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 }
 
 /* Wrapper function to call ldm functions as needed */
-static void ldm_handleLdm() {
+static void ldm_handleLdm(int* nbMatches) {
     int noMoreLdms = getNextMatch();
 }
 
@@ -861,6 +861,7 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
         {   U32 const litlen = (U32)(ip - anchor);
             U32 const ll0 = !litlen;
             U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, ip, iend, dictMode, rep, ll0, minMatch);
+            ldm_handleLdm(&nbMatches);
             if (!nbMatches) { ip++; continue; }
 
             /* initialize opt[0] */
@@ -975,6 +976,8 @@ ZSTD_compressBlock_opt_generic(ZSTD_matchState_t* ms,
                 U32 const basePrice = previousPrice + ZSTD_litLengthPrice(0, optStatePtr, optLevel);
                 U32 const nbMatches = ZSTD_BtGetAllMatches(matches, ms, &nextToUpdate3, inr, iend, dictMode, opt[cur].rep, ll0, minMatch);
                 U32 matchNb;
+                
+                ldm_handleLdm(&nbMatches);
                 if (!nbMatches) {
                     DEBUGLOG(7, "rPos:%u : no match found", cur);
                     continue;

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -838,8 +838,20 @@ static int ldm_getNextMatch(rawSeqStore_t* ldmSeqStore,
 }
 
 /* Adds an LDM if it's long enough */
-static void ldm_maybeAddLdm() {
+static void ldm_maybeAddLdm(ZSTD_match_t* matches, U32 nbMatches,
+                            U32 matchStartPosInBlock, U32 matchEndPosInBlock,
+                            U32 matchOffset, U32 currPosInBlock) {
+    /* Check that current block position is not outside of the match */
+    if (currPosInBlock < matchStartPosInBlock || currPosInBlock >= matchEndPosInBlock)
+        return;
+    U32 posDiff = currPosInBlock - matchStartPosInBlock;
+    assert(posDiff < matchEndPosInBlock - matchStartPosInBlock);
+    U32 matchLengthAdjusted = matchEndPosInBlock - matchStartPosInBlock - posDiff;
+    U32 matchOffsetAdjusted = matchOffset + posDiff;
 
+    if (matchLengthAdjusted >= matches[nbMatches-1]) {
+        
+    }
 }
 
 /* Updates the pos field in rawSeqStore */
@@ -849,12 +861,12 @@ static void ldm_maybeUpdateSeqStoreReadPos() {
 
 /* Wrapper function to call ldm functions as needed */
 static void ldm_handleLdm(ZSTD_match_t* matches, int* nbMatches,
-                          U32* matchStartPosInBlock, U32* matchEndPosInBlock,
+                          U32* matchStartPosInBlock, U32* matchEndPosInBlock, U32* matchOffset,
                           U32 currPosInBlock, U32 remainingBytes) {
     if (currPosInBlock >= matchEndPosInBlock) {
         int noMoreLdms = ldm_getNextMatch(matchStartPosInBlock, matchEndPosInBlock, remainingBytes);
     }
-    ldm_maybeAddLdm(matches, currPosInBlock, matchStartPosInBlock, matchEndPosInBlock);
+    ldm_maybeAddLdm(matches, *nbMatches, *matchStartPosInBlock, *matchEndPosInBlock, *matchOffset, currPosInBlock);
 }
 
 

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -764,6 +764,34 @@ FORCE_INLINE_TEMPLATE U32 ZSTD_BtGetAllMatches (
     }
 }
 
+/*-*******************************
+*  LDM util functions
+*********************************/
+
+static int ldm_splitSequence() {
+
+}
+
+/* Returns 1 if the rest of the block is just LDM literals */
+static int ldm_getNextMatch() {
+    int ret = ldm_splitSequence();
+}
+
+/* Adds an LDM if it's long enough */
+static void ldm_maybeAddLdm() {
+
+}
+
+/* Updates the pos field in rawSeqStore */
+static void ldm_maybeUpdateSeqStoreReadPos() {
+
+}
+
+/* Wrapper function to call ldm functions as needed */
+static void ldm_handleLdm() {
+    int noMoreLdms = getNextMatch();
+}
+
 
 /*-*******************************
 *  Optimal parser

--- a/lib/compress/zstd_opt.c
+++ b/lib/compress/zstd_opt.c
@@ -789,6 +789,15 @@ static void ldm_skipOvershotBytes(rawSeqStore_t* rawSeqStore, U32 bytesOvershot)
     }
 }*/
 
+
+static void ldm_voidSequences(rawSeqStore_t* ldmSeqStore, U32 overshotBytes) {
+    U32 posAdjustment;
+    U32 bytesAdjustment;
+    while (overshotBytes > 0 && ldmSeqStore->pos < ldmSeqStore->size) {
+
+    }
+}
+
 static void ldm_skipSequences(rawSeqStore_t* rawSeqStore, size_t srcSize, U32 const minMatch) {
     while (srcSize > 0 && rawSeqStore->pos < rawSeqStore->size) {
         printf("ldm_skipSequences(): %u remaining\n", srcSize);

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -266,7 +266,7 @@ static void ZSTDMT_releaseBuffer(ZSTDMT_bufferPool* bufPool, buffer_t buf)
 
 /* =====   Seq Pool Wrapper   ====== */
 
-static rawSeqStore_t kNullRawSeqStore = {NULL, NULL, 0, 0, 0};
+static rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0, 0};
 
 typedef ZSTDMT_bufferPool ZSTDMT_seqPool;
 
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, NULL, 0, 0, 0};
+    rawSeqStore_t seq = {NULL, 0, 0, 0, 0};
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -266,7 +266,7 @@ static void ZSTDMT_releaseBuffer(ZSTDMT_bufferPool* bufPool, buffer_t buf)
 
 /* =====   Seq Pool Wrapper   ====== */
 
-static rawSeqStore_t kNullRawSeqStore = {NULL, 0, 0, 0};
+static rawSeqStore_t kNullRawSeqStore = {NULL, NULL, 0, 0, 0};
 
 typedef ZSTDMT_bufferPool ZSTDMT_seqPool;
 

--- a/lib/compress/zstdmt_compress.c
+++ b/lib/compress/zstdmt_compress.c
@@ -277,7 +277,7 @@ static size_t ZSTDMT_sizeof_seqPool(ZSTDMT_seqPool* seqPool)
 
 static rawSeqStore_t bufferToSeq(buffer_t buffer)
 {
-    rawSeqStore_t seq = {NULL, 0, 0, 0};
+    rawSeqStore_t seq = {NULL, NULL, 0, 0, 0};
     seq.seq = (rawSeq*)buffer.start;
     seq.capacity = buffer.capacity / sizeof(rawSeq);
     return seq;

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1323,8 +1323,6 @@ optCSize19=$(datagen -g2M | zstd -19 -c | wc -c)
 longCSize19=$(datagen -g2M | zstd -19 --long -c | wc -c)
 optCSize19wlog23=$(datagen -g2M | zstd -19 -c  --zstd=wlog=23 | wc -c)
 longCSize19wlog23=$(datagen -g2M | zstd -19 -c --long=23 | wc -c)
-optCSize19wlog27=$(datagen -g5M | zstd -19 -c  --zstd=wlog=27 | wc -c)
-longCSize19wlog27=$(datagen -g5M | zstd -19 -c --long=27 | wc -c)
 optCSize22=$(datagen -g900K | zstd -22 --ultra -c | wc -c)
 longCSize22=$(datagen -g900K | zstd -22 --ultra --long -c | wc -c)
 if [ "$longCSize16" -gt "$optCSize16" ]; then
@@ -1335,9 +1333,6 @@ elif [ "$longCSize19" -gt "$optCSize19" ]; then
     exit 1
 elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
     echo using --long on compression level 19 with wLog=23 should not cause compressed size regression
-    exit 1
-elif [ "$longCSize19wlog27" -gt "$optCSize19wlog27" ]; then
-    echo using --long on compression level 19 with wLog=27 should not cause compressed size regression
     exit 1
 elif [ "$longCSize22" -gt "$optCSize22" ]; then
     echo using --long on compression level 22 should not cause compressed size regression

--- a/tests/playTests.sh
+++ b/tests/playTests.sh
@@ -1187,6 +1187,7 @@ roundTripTest -g1000K "1 --single-thread --long"
 roundTripTest -g517K "6 --single-thread --long"
 roundTripTest -g516K "16 --single-thread --long"
 roundTripTest -g518K "19 --single-thread --long"
+roundTripTest -g2M "22 --single-thread --ultra --long"
 fileRoundTripTest -g5M "3 --single-thread --long"
 
 
@@ -1196,6 +1197,7 @@ then
     println "\n===>  zstdmt round-trip tests "
     roundTripTest -g4M "1 -T0"
     roundTripTest -g8M "3 -T2"
+    roundTripTest -g8M "3 -T0 --long"
     roundTripTest -g8000K "2 --threads=2"
     fileRoundTripTest -g4M "19 -T2 -B1M"
 
@@ -1314,6 +1316,33 @@ roundTripTest -g1M -P50 "1 --single-thread --long=29" " --long=28 --memory=512MB
 roundTripTest -g1M -P50 "1 --single-thread --long=29" " --zstd=wlog=28 --memory=512MB"
 
 
+println "\n===>  zstd long distance matching with optimal parser compressed size tests "
+optCSize16=$(datagen -g511K | zstd -16 -c | wc -c)
+longCSize16=$(datagen -g511K | zstd -16 --long -c | wc -c)
+optCSize19=$(datagen -g2M | zstd -19 -c | wc -c)
+longCSize19=$(datagen -g2M | zstd -19 --long -c | wc -c)
+optCSize19wlog23=$(datagen -g2M | zstd -19 -c  --zstd=wlog=23 | wc -c)
+longCSize19wlog23=$(datagen -g2M | zstd -19 -c --long=23 | wc -c)
+optCSize19wlog27=$(datagen -g5M | zstd -19 -c  --zstd=wlog=27 | wc -c)
+longCSize19wlog27=$(datagen -g5M | zstd -19 -c --long=27 | wc -c)
+optCSize22=$(datagen -g900K | zstd -22 --ultra -c | wc -c)
+longCSize22=$(datagen -g900K | zstd -22 --ultra --long -c | wc -c)
+if [ "$longCSize16" -gt "$optCSize16" ]; then
+    echo using --long on compression level 16 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19" -gt "$optCSize19" ]; then
+    echo using --long on compression level 19 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19wlog23" -gt "$optCSize19wlog23" ]; then
+    echo using --long on compression level 19 with wLog=23 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize19wlog27" -gt "$optCSize19wlog27" ]; then
+    echo using --long on compression level 19 with wLog=27 should not cause compressed size regression
+    exit 1
+elif [ "$longCSize22" -gt "$optCSize22" ]; then
+    echo using --long on compression level 22 should not cause compressed size regression
+    exit 1
+fi
 
 
 if [ "$1" != "--test-large-data" ]; then


### PR DESCRIPTION
Draft PR
Preliminary results regarding compressed size:

* 5259889920 (5GB) bytes: 5 Linux kernels concatenated: versions 4.19.148, 5.4.68, 5.8.12, 5.9-rc7, 5.8.12: 
    * Old: Level 22 - long mode - window log = 27
        * 622643668 → 11.84%
    * Old: Level 22 - no long mode - window log = 27
        * 624737369 → 11.88%
    * New: Level 22 - long mode - window log = 27
        * 622639116 → 11.84%
* 1995028480 (2GB) bytes: 2 relatively close Linux kernels concatenated: 5.8.12, 5.9-rc7
    * Old: Level 22 - long mode - window log = 30
        * 123668734 → 6.20%
    * Old: Level 22 - no long mode - window log = 30
        * 131944438 → 6.61%
    * New: Level 22 - long mode - window log = 30
        * 122466509 → 6.14%
* 211950592 (200MB) bytes: silesia.tar
    * Old: Level 22 - long mode - window log = 27
        * 52777588 → 24.90%
    * Old: Level 22 - no long mode - window log = 27
        * 52701591 → 24.87%
    * New: Level 22 - long mode - window log = 27
        * 52699843 → 24.86% 

New algorithm approach:

* Essentially, we will use the LDM rawSeqStore given to us in a similar way to the current LDM insertion algorithm works. What this means is that essentially for each new block, the LDM sequence at position pos within the LDM seqStore is guaranteed to start at the same relative position as the block. That is, for each n bytes processed in the block, n bytes are processed and consumed in the LDM seqstore, and the member pos will point to relevant sequence.
* As such, all of our calculations are purely relative within each block, and the approach is robust against issues such as window updates, etc.
